### PR TITLE
Update barrialFreestanding.json

### DIFF
--- a/dc/en/barrialFreestanding.json
+++ b/dc/en/barrialFreestanding.json
@@ -20,7 +20,23 @@
   "straight": "Straight",
   "curved": "Curved",
   "bacdal": "Bacdal",
+  "color": "Colour",
+  "12.5kg": "2x 12.5 kg",
+  "25kg": "1x 25 kg",
 
+  "BS13700": "BS 13700 with optimisable (1250/1450mm) rail",
+  "BS13700-helper": "Maximum slope of roof = 5° (8.5%)",
+  "BS13700-SB": "BS 13700 with 1250mm rail (no parapet)",
+  "BS13700-SB-helper": "Maximum slope of roof = 1.15° (2%)",
+  "EN13374": "EN 13374 with optimisable (1250/1450mm) rail",
+  "EN13374-helper": "Maximum slope of roof = 10° (17%)",
+  "EN13374-950": "EN 13374 with 950mm rail",
+  "EN13374-950-helper": "Maximum slope of roof = 10° (17%)",
+  "EN13374-SB": "EN 13374 with 1250mm rail (no parapet)",
+  "EN13374-SB-helper": "Maximum slope of roof = 1.15° (2%)",
+  "ISO14122-3": "ISO EN 14122-3 with 1250mm rail",
+  "ISO14122-3-helper": "Maximum slope of roof = 3° (5%)",
+  
   "plinth-is-required": "A toe board is required",
 
   "barrialFreestanding": "Barrial freestanding",


### PR DESCRIPTION
Added:

  "color": "Colour",
  "12.5kg": "2x 12.5 kg",
  "25kg": "1x 25 kg",

  "BS13700": "BS 13700 with optimisable (1250/1450mm) rail",
  "BS13700-helper": "Maximum slope of roof = 5° (8.5%)",
  "BS13700-SB": "BS 13700 with 1250mm rail (no parapet)",
  "BS13700-SB-helper": "Maximum slope of roof = 1.15° (2%)",
  "EN13374": "EN 13374 with optimisable (1250/1450mm) rail",
  "EN13374-helper": "Maximum slope of roof = 10° (17%)",
  "EN13374-950": "EN 13374 with 950mm rail",
  "EN13374-950-helper": "Maximum slope of roof = 10° (17%)",
  "EN13374-SB": "EN 13374 with 1250mm rail (no parapet)",
  "EN13374-SB-helper": "Maximum slope of roof = 1.15° (2%)",
  "ISO14122-3": "ISO EN 14122-3 with 1250mm rail",
  "ISO14122-3-helper": "Maximum slope of roof = 3° (5%)",